### PR TITLE
Ensure 4:3 aspect ratio

### DIFF
--- a/src/pre.js
+++ b/src/pre.js
@@ -1,2 +1,4 @@
 // Don't copy canvas image back into RAM in SDL_LockSurface()
 Module['screenIsReadOnly'] = true;
+// Ensure 4:3 aspect ratio
+Module['forcedAspectRatio'] = 4 / 3;


### PR DESCRIPTION
Ensure 4:3 aspect ratio, especially in full screen, as dos games tend to have resolutions that are not 4/3 but should be displayed as 4/3, like on an old monitor.

I assume this is relevant to both the main and the SDL2 branches.