### PR TITLE
ISO file support in CDROM module

### DIFF
--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -23,7 +23,6 @@
 
 #include "SDL_version.h"
 
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -23,6 +23,7 @@
 
 #include "SDL_version.h"
 
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -177,11 +178,11 @@ int CDROM_GetMountType(char* path, int forceCD) {
 		if (strcmp(buffer,cdName)==0) return 0;
 	};
 #endif
-	
+#endif /* !EMSCRIPTEN */
 	// Detect ISO
 	struct stat file_stat;
 	if ((stat(path, &file_stat) == 0) && (file_stat.st_mode & S_IFREG)) return 1; 
-#endif /* !EMSCRIPTEN */
+
 	return 2;
 }
 

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -86,7 +86,7 @@ public:
 	virtual void	InitNewMedia		(void) {};
 };	
 
-#if !defined(EMSCRIPTEN) && !SDL_VERSION_ATLEAST(2,0,0)
+#if !SDL_VERSION_ATLEAST(2,0,0)
 class CDROM_Interface_SDL : public CDROM_Interface
 {
 public:
@@ -115,7 +115,7 @@ private:
 	int		driveID;
 	Uint32	oldLeadOut;
 };
-#endif /* !defined(EMSCRIPTEN) && !SDL_VERSION_ATLEAST(2,0,0) */
+#endif /* !SDL_VERSION_ATLEAST(2,0,0) */
 
 class CDROM_Interface_Fake : public CDROM_Interface
 {
@@ -135,7 +135,7 @@ public:
 	bool	LoadUnloadMedia		(bool /*unload*/) { return true; };
 };	
 
-#ifndef EMSCRIPTEN
+//#ifndef EMSCRIPTEN
 class CDROM_Interface_Image : public CDROM_Interface
 {
 private:
@@ -241,7 +241,7 @@ typedef	std::vector<Track>::iterator	track_it;
 	std::string	mcn;
 	Bit8u	subUnit;
 };
-#endif /* !EMSCRIPTEN */
+//#endif /* !EMSCRIPTEN */
 
 #if !SDL_VERSION_ATLEAST(2,0,0)
 

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -165,7 +165,9 @@ CDROM_Interface_Image::CDROM_Interface_Image(Bit8u subUnit)
 {
 	images[subUnit] = this;
 	if (refCount == 0) {
-//		player.mutex = SDL_CreateMutex();
+#ifndef EMSCRIPTEN
+		player.mutex = SDL_CreateMutex();
+#endif
 		if (!player.channel) {
 			player.channel = MIXER_AddChannel(&CDAudioCallBack, 44100, "CDAUDIO");
 		}
@@ -180,7 +182,9 @@ CDROM_Interface_Image::~CDROM_Interface_Image()
 	if (player.cd == this) player.cd = NULL;
 	ClearTracks();
 	if (refCount == 0) {
-//		SDL_DestroyMutex(player.mutex);
+#ifndef EMSCRIPTEN
+		SDL_DestroyMutex(player.mutex);
+#endif
 		player.channel->Enable(false);
 	}
 }
@@ -255,7 +259,9 @@ bool CDROM_Interface_Image::GetMediaTrayStatus(bool& mediaPresent, bool& mediaCh
 bool CDROM_Interface_Image::PlayAudioSector(unsigned long start,unsigned long len)
 {
 	// We might want to do some more checks. E.g valid start and length
-//	SDL_mutexP(player.mutex);
+#ifndef EMSCRIPTEN
+	SDL_mutexP(player.mutex);
+#endif
 	player.cd = this;
 	player.currFrame = start;
 	player.targetFrame = start + len;
@@ -268,7 +274,9 @@ bool CDROM_Interface_Image::PlayAudioSector(unsigned long start,unsigned long le
 		//Real drives either fail or succeed as well
 	} else player.isPlaying = true;
 	player.isPaused = false;
-//	SDL_mutexV(player.mutex);
+#ifndef EMSCRIPTEN
+	SDL_mutexV(player.mutex);
+#endif	
 	return true;
 }
 
@@ -350,8 +358,10 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 		player.channel->AddSilence();
 		return;
 	}
-	
-//	SDL_mutexP(player.mutex);
+
+#ifndef EMSCRIPTEN
+	SDL_mutexP(player.mutex);
+#endif
 	while (player.bufLen < (Bits)len) {
 		bool success;
 		if (player.targetFrame > player.currFrame)
@@ -367,7 +377,9 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 			player.isPlaying = false;
 		}
 	}
-//	SDL_mutexV(player.mutex);
+#ifndef EMSCRIPTEN
+	SDL_mutexV(player.mutex);
+#endif
 	if (player.ctrlUsed) {
 		Bit16s sample0,sample1;
 		Bit16s * samples=(Bit16s *)&player.buffer;

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -16,7 +16,7 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
-
+#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include "regs.h"
@@ -311,11 +311,11 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 #endif
 		} break;
 #endif	// !SDL_VERSION_ATLEAST(2,0,0)
+#endif /* !EMSCRIPTEN */
 	case 0x01:	// iso cdrom interface	
 		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: Mounting iso file as cdrom: %s", physicalPath);
 		cdrom[numDrives] = new CDROM_Interface_Image((Bit8u)numDrives);
 		break;
-#endif /* !EMSCRIPTEN */
 	case 0x02:	// fake cdrom interface (directories)
 		cdrom[numDrives] = new CDROM_Interface_Fake;
 		LOG(LOG_MISC,LOG_NORMAL)("MSCDEX: Mounting directory as cdrom: %s",physicalPath);
@@ -392,20 +392,15 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 
 	if (dinfo[0].drive-1==_drive) {
 		CDROM_Interface *_cdrom = cdrom[numDrives];
-#ifndef EMSCRIPTEN
 		CDROM_Interface_Image *_cdimg = CDROM_Interface_Image::images[numDrives];
-#endif
+
 		for (Bit16u i=GetNumDrives(); i>0; i--) {
 			dinfo[i] = dinfo[i-1];
 			cdrom[i] = cdrom[i-1];
-#ifndef EMSCRIPTEN
 			CDROM_Interface_Image::images[i] = CDROM_Interface_Image::images[i-1];
-#endif
 		}
 		cdrom[0] = _cdrom;
-#ifndef EMSCRIPTEN
 		CDROM_Interface_Image::images[0] = _cdimg;
-#endif
 		dinfo[0].drive		= (Bit8u)_drive;
 		dinfo[0].physDrive	= (Bit8u)toupper(physicalPath[0]);
 		subUnit = 0;

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -16,7 +16,6 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
-#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include "regs.h"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1338,7 +1338,6 @@ public:
 					}
 				}
 			} else if (fstype=="iso") {
-#ifndef EMSCRIPTEN
 				if (Drives[drive-'A']) {
 					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_ALREADY_MOUNTED"));
 					return;
@@ -1388,9 +1387,6 @@ public:
 					tmp += "; " + paths[i];
 				}
 				WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
-#else /* EMSCRIPTEN */
-			WriteOut(MSG_Get("MSCDEX_ERROR_NOT_SUPPORTED"));
-#endif
 			} else {
 				FILE *newDisk = fopen(temp_line.c_str(), "rb+");
 				fseek(newDisk,0L, SEEK_END);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -17,8 +17,6 @@
  */
 
 
-#ifndef EMSCRIPTEN
-
 #include <cctype>
 #include <cstring>
 #include "cdrom.h"
@@ -554,4 +552,3 @@ bool isoDrive :: lookup(isoDirEntry *de, const char *path) {
 	return true;
 }
 
-#endif /* !EMSCRIPTEN */

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -577,6 +577,7 @@ bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name);
 cdromDrive::cdromDrive(const char driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error)
 		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid) {
 	// Init mscdex
+printf("Initializing CDROM drive");
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	strcpy(info, "CDRom ");
 	strcat(info, startdir);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -577,7 +577,6 @@ bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name);
 cdromDrive::cdromDrive(const char driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error)
 		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid) {
 	// Init mscdex
-printf("Initializing CDROM drive");
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	strcpy(info, "CDRom ");
 	strcat(info, startdir);


### PR DESCRIPTION
I believe you can safely re-enable ISO support in em-dosbox. The mutex functionality isn't supported in the SDL2 port, but that's partly because Javascript is inherently single threaded. The necessary functionality is in the language itself. 

Give this a try and see if it meets with your approval.