### PR TITLE
Fix emcc detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_CONFIG_SRCDIR(README)
 
 dnl Check for Emscripten is done early because it needs to change host triplet.
 AS_CASE([$CC],
+        [*emcc.py], [enable_emscripten="yes"],
         [*emcc], [enable_emscripten="yes"],
         [enable_emscripten="no"])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,4 +36,4 @@ endif
 # https://stackoverflow.com/questions/1779984/header-dependency-in-automake
 BUILT_SOURCES=version.stamp
 version.stamp:
-	python version.py ../include/version.h .. $(CXX)
+	python version.py ../include/version.h .. "$(CXX)"


### PR DESCRIPTION
I used the latest stable emscripten version (1.37.36) and noticed that `CC `now points to `python /home/osboxes/emsdk/emscripten/1.37.36/em++.py`, which breaks build (see src/Makefile.am change). Also, as `CC` has changed, configuring project with emconfigure no longer caused generation of asm.js code (see configure.ac change). This pr fixes that.