### PR TITLE
Fix WASM setting for new emscripten

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,8 @@ dosbox_LDFLAGS+=--memory-init-file 0
 endif
 if WEBASSEMBLY
 dosbox_LDFLAGS+=-s WASM=1
+else
+dosbox_LDFLAGS+=-s WASM=0
 endif
 endif
 


### PR DESCRIPTION
New versions of emscripten turn WASM on by default, so Makefile.am needs to manually disable it if it's not meant to be enabled.